### PR TITLE
Add non-existing API-Key for corresponding test

### DIFF
--- a/src/test/java/de/meggsimum/w3w/What3WordsTest.java
+++ b/src/test/java/de/meggsimum/w3w/What3WordsTest.java
@@ -91,7 +91,7 @@ public class What3WordsTest extends TestCase {
 	 * Test for exception in case of an invalid API-key
 	 */
 	public void testWhat3WordsException() {
-		What3Words w3w = new What3Words(API_KEY);
+		What3Words w3w = new What3Words("non-existing-api-key");
 		double[] coords = { 49.422636, 8.320833 };
 		boolean thrown = false;
 		try {


### PR DESCRIPTION
This mainly reverts 2a292d301386, so the unit test for an invalid API-key passes again.
