### PR TITLE
error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # w3w-java-wrapper
-Java wrapper for the [what3words](http://what3words.com/) [web-API](http://developer.what3words.com/api).
+Java wrapper for the [what3words](http://what3words.com/) [web-API](https://docs.what3words.com/api/v2/).
 
 Use the what3words API in your Java applications.
 

--- a/src/main/java/de/meggsimum/w3w/ThreeWords.java
+++ b/src/main/java/de/meggsimum/w3w/ThreeWords.java
@@ -31,6 +31,13 @@ public class ThreeWords {
     }
 
     /**
+     * @return the 3 word address with full stops as `first.second.third`
+     */
+    public String get3WordAddress() {
+        return String.format("%s.%s.%s",this.first, this.second, this.third);
+    }
+
+    /**
      * @return first word of this "w3w-address"
      */
     public String getFirst() {

--- a/src/main/java/de/meggsimum/w3w/What3Words.java
+++ b/src/main/java/de/meggsimum/w3w/What3Words.java
@@ -14,7 +14,7 @@ import org.json.JSONObject;
 /**
  * A Java wrapper for the What3Words Web-API.
  *
- * @see http://developer.what3words.com/api/
+ * @see <a href="https://docs.what3words.com/api/v2/">https://docs.what3words.com/api/v2/</a>
  *
  * @author Christian Mayer, meggsimum
  */
@@ -129,10 +129,21 @@ public class What3Words {
 
                 return coords;
 
-            } else if (json.has("error")) {
+            } else if (json.has("code")) {
 
                 throw new What3WordsException("Error returned from w3w API: "
                         + json.getString("message"));
+
+            } else if (json.has("status")) {
+
+                if(json.get("status") instanceof JSONObject) {
+                    JSONObject status = json.getJSONObject("status");
+                    throw new What3WordsException("Error returned from w3w API: "
+                            + status.getString("message"));
+                } else {
+                    throw new What3WordsException(
+                            "Undefined error while fetching words by position");
+                }
 
             } else {
                 throw new What3WordsException(
@@ -149,7 +160,7 @@ public class What3Words {
      * Converts a position object into a "w3w-address" object (in the given
      * language)
      *
-     * @param position object holding the coordinates to be transformed
+     * @param coordinates object holding the coordinates to be transformed
      * @param language string defining the language of the words (e.g. "de")
      * @return "w3w-address" object in the given language
      * @throws IOException
@@ -164,7 +175,7 @@ public class What3Words {
      * Converts a position object into a "w3w-address" object with default
      * language.
      *
-     * @param position object holding the coordinates to be transformed
+     * @param coordinates object holding the coordinates to be transformed
      * @return "w3w-address" object
      * @throws IOException
      * @throws What3WordsException
@@ -216,6 +227,17 @@ public class What3Words {
             } else if (json.has("code")) {
                 throw new What3WordsException("Error returned from w3w API: "
                         + json.getString("message"));
+
+            } else if (json.has("status")) {
+
+                if(json.get("status") instanceof JSONObject) {
+                    JSONObject status = json.getJSONObject("status");
+                    throw new What3WordsException("Error returned from w3w API: "
+                            + status.getString("message"));
+                } else {
+                    throw new What3WordsException(
+                            "Undefined error while fetching words by position");
+                }
 
             } else {
                 throw new What3WordsException(

--- a/src/test/java/de/meggsimum/w3w/What3WordsTest.java
+++ b/src/test/java/de/meggsimum/w3w/What3WordsTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assume.assumeNotNull;
 public class What3WordsTest {
 
     /**
-     * The api is read from command line arguments or can also be entered here manually.
+     * The api key is read from command line arguments or can also be entered here manually.
      */
     private String apiKey = null;
     /**
@@ -39,6 +39,10 @@ public class What3WordsTest {
         // Try to read the API key from system properties only in case it was not hard coded.
         if (apiKey == null) {
             apiKey = System.getProperty(API_KEY_PROPERTY);
+        }
+        // Fall back to environment variable in case API key was not provided as property
+        if(apiKey == null) {
+            apiKey = System.getenv(API_KEY_PROPERTY);
         }
         assumeNotNull(apiKey);
     }

--- a/src/test/java/de/meggsimum/w3w/What3WordsTest.java
+++ b/src/test/java/de/meggsimum/w3w/What3WordsTest.java
@@ -164,4 +164,23 @@ public class What3WordsTest {
         assertEquals(16.099389, coords[1], 0.000001);
     }
 
+    @Test
+    public void testWordsToPositionInvalid3WordAddress() throws Exception {
+        expectedException.expect(Exception.class);
+        expectedException.expectMessage("Invalid or non-existent 3 word address");
+        What3Words w3w = new What3Words(apiKey);
+        String[] words = {"no", "address", "here"};
+        double[] coords = w3w.wordsToPosition(words);
+
+    }
+
+    @Test
+    public void testPositionToWordsInvalidLanguage() throws Exception {
+        expectedException.expect(Exception.class);
+        expectedException.expectMessage("The 'lang' parameter is invalid or missing a language code");
+        What3Words w3w = new What3Words(apiKey);
+        double[] coords = {49.422636, 8.320833};
+        String[] words = w3w.positionToWords(coords, "XX");
+
+    }
 }

--- a/src/test/java/de/meggsimum/w3w/What3WordsTest.java
+++ b/src/test/java/de/meggsimum/w3w/What3WordsTest.java
@@ -111,7 +111,7 @@ public class What3WordsTest {
     // Object API tests
 
     @Test
-    public void voidTestWordsToPositionObj() throws Exception {
+    public void testWordsToPositionObj() throws Exception {
         What3Words w3w = new What3Words(apiKey);
         ThreeWords words = new ThreeWords("goldfish", "fuzzy", "aggregates");
         Coordinates coords = w3w.wordsToPosition(words);
@@ -120,7 +120,7 @@ public class What3WordsTest {
     }
 
     @Test
-    public void voidTestWordsToPositionWithLangObj() throws Exception {
+    public void testWordsToPositionWithLangObj() throws Exception {
         What3Words w3w = new What3Words(apiKey);
         ThreeWords words = new ThreeWords("kleid", "ober", "endlos");
         Coordinates coords = w3w.wordsToPosition(words, "de");

--- a/src/test/java/de/meggsimum/w3w/What3WordsTest.java
+++ b/src/test/java/de/meggsimum/w3w/What3WordsTest.java
@@ -100,7 +100,7 @@ public class What3WordsTest {
      * Test for exception in case of an invalid API-key
      */
     @Test
-    public void testWhat3WordsException() throws Exception {
+    public void testInvalidWhat3WordsAPIKeyException() throws Exception {
         expectedException.expect(Exception.class);
         expectedException.expectMessage("Authentication failed; invalid API key");
         What3Words w3w = new What3Words(UUID.randomUUID().toString() + apiKey);
@@ -142,6 +142,26 @@ public class What3WordsTest {
         Coordinates coordinates = new Coordinates(49.422636, 8.320833);
         ThreeWords threeWords = w3w.positionToWords(coordinates, "de");
         assertEquals(new ThreeWords("kleid", "ober", "endlos"), threeWords);
+    }
+
+    @Test
+    public void testGerman3wordAddress()throws Exception  {
+        What3Words w3w = new What3Words(apiKey, "de");
+        String[] words = {"zulassen", "fährst", "wächst"};
+        double[] coords = w3w.wordsToPosition(words);
+        assertEquals(2, coords.length);
+        assertEquals(50.049496, coords[0], 0.000001);
+        assertEquals(-110.681137, coords[1], 0.000001);
+    }
+
+    @Test
+    public void testFrench3wordAddress()throws Exception  {
+        What3Words w3w = new What3Words(apiKey, "fr");
+        String[] words = {"garçon", "étaler", "frôler"};
+        double[] coords = w3w.wordsToPosition(words);
+        assertEquals(2, coords.length);
+        assertEquals(48.246860, coords[0], 0.000001);
+        assertEquals(16.099389, coords[1], 0.000001);
     }
 
 }


### PR DESCRIPTION
Hi Christian,

you will find in this pull request an improvement of the error handling. Indeed what3words API can send back multiple error format containing `status` with a code, or as a  JSONObject containing then `status` with the `HTTP Status code`, `code` containing the error code.

I also added two test cases with French and German addresses.

Best regards
